### PR TITLE
修复子菜单个数超过3个时，菜单在屏幕中间和屏幕两边的切换时造成位置错乱的问题

### DIFF
--- a/app/src/main/java/com/huxq17/example/floatball/MainActivity.java
+++ b/app/src/main/java/com/huxq17/example/floatball/MainActivity.java
@@ -153,6 +153,8 @@ public class MainActivity extends Activity {
         };
         mFloatballManager.addMenuItem(personItem)
                 .addMenuItem(walletItem)
+                .addMenuItem(walletItem)
+                .addMenuItem(settingItem)
                 .addMenuItem(settingItem)
                 .buildMenu();
     }

--- a/app/src/main/java/com/huxq17/example/floatball/floatball/FloatBallManager.java
+++ b/app/src/main/java/com/huxq17/example/floatball/floatball/FloatBallManager.java
@@ -139,7 +139,6 @@ public class FloatBallManager {
         if (!isShowing) return;
         isShowing = false;
         floatBall.detachFromWindow(mWindowManager);
-        floatMenu.detachFromWindow(mWindowManager);
     }
 
     public void onConfigurationChanged(Configuration newConfig) {
@@ -153,6 +152,14 @@ public class FloatBallManager {
 
     public void setOnFloatBallClickListener(OnFloatBallClickListener listener) {
         mFloatballClickListener = listener;
+    }
+
+    /**
+     * 移动完毕，刷新菜单状态。move over，refresh menu state.
+     */
+    public void moveOver() {
+        // TODO 刷新position 然后刷新宽高
+        floatMenu.refreshState();
     }
 
     public interface OnFloatBallClickListener {

--- a/app/src/main/java/com/huxq17/example/floatball/floatball/floatball/FloatBall.java
+++ b/app/src/main/java/com/huxq17/example/floatball/floatball/floatball/FloatBall.java
@@ -169,6 +169,10 @@ public class FloatBall extends FrameLayout implements ICarrier {
             if (isClick) {
                 onClick();
             } else {
+                // 用于再次计算菜单应该有的宽高
+                floatBallManager.floatballX = mLayoutParams.x;
+                floatBallManager.floatballY = mLayoutParams.y;
+                floatBallManager.moveOver();    // 回调到外面让manager重新布局菜单
                 moveToEdge(true, false);
             }
         }

--- a/app/src/main/java/com/huxq17/example/floatball/floatball/menu/FloatMenu.java
+++ b/app/src/main/java/com/huxq17/example/floatball/floatball/menu/FloatMenu.java
@@ -106,6 +106,19 @@ public class FloatMenu extends FrameLayout {
         }
     }
 
+    /**
+     * 刷新菜单状态（重新计算位置 大小）
+     */
+    public void refreshState() {
+        mBallSize = floatBallManager.getBallSize();
+        mLayoutParams.x = floatBallManager.floatballX;
+        mLayoutParams.y = floatBallManager.floatballY - mSize / 2;
+        mPosition = computeMenuLayout(mLayoutParams);
+        refreshPathMenu(mPosition);
+        mMenuLayout.refreshState(mPosition, mDuration);
+        mMenuLayout.measure(-2147483288, -2147483288);  // 模拟系统重新计算宽高 -2147483288是根据正常情况下系统的传值抓取的（其实是也没有使用这两个值，无所谓的）
+    }
+
     public void detachFromWindow(WindowManager windowManager) {
         if (isAdded) {
             toggle(0);

--- a/app/src/main/java/com/huxq17/example/floatball/floatball/menu/MenuLayout.java
+++ b/app/src/main/java/com/huxq17/example/floatball/floatball/menu/MenuLayout.java
@@ -123,10 +123,8 @@ public class MenuLayout extends ViewGroup implements ICarrier {
      */
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        System.out.println("改变 宽高：mToDegrees:" + mToDegrees + "  mFromDegrees:" + mFromDegrees + "  mChildPadding:" + mChildPadding + "   MIN_RADIUS:" + MIN_RADIUS);
         mRadius = computeRadius(Math.abs(mToDegrees - mFromDegrees), getChildCount(),
                 mChildSize, mChildPadding, MIN_RADIUS);
-        System.out.println("改变 宽高：mRadius:" + mRadius + "  mChildSize:" + mChildSize + "  widthMeasureSpec:" + widthMeasureSpec + "   heightMeasureSpec:" + heightMeasureSpec);
         int layoutPadding = 10;
         int size = mRadius * 2 + mChildSize + mChildPadding + layoutPadding * 2;
         setMeasuredDimension(size, size);

--- a/app/src/main/java/com/huxq17/example/floatball/floatball/menu/MenuLayout.java
+++ b/app/src/main/java/com/huxq17/example/floatball/floatball/menu/MenuLayout.java
@@ -29,44 +29,49 @@ public class MenuLayout extends ViewGroup implements ICarrier {
     private int centerY = 0;
     private ScrollRunner mRunner;
 
+    /**
+     * 计算菜单中心的xy  之前是使用getWidth和getHeight，这样不能获取到及时measure的宽高，修改为了getMeasuredWidth 和 getMeasuredHeight。这样计算出来的位置才是正确的
+     *
+     * @param position
+     */
     public void computeCenterXY(int position) {
         switch (position) {
             case FloatMenu.LEFT_TOP://左上
-                centerX = getWidth() / 2 - getRadiusAndPadding();
-                centerY = getHeight() / 2 - getRadiusAndPadding();
+                centerX = getMeasuredWidth() / 2 - getRadiusAndPadding();
+                centerY = getMeasuredHeight() / 2 - getRadiusAndPadding();
                 break;
             case FloatMenu.LEFT_CENTER://左中
-                centerX = getWidth() / 2 - getRadiusAndPadding();
-                centerY = getHeight() / 2;
+                centerX = getMeasuredWidth() / 2 - getRadiusAndPadding();
+                centerY = getMeasuredHeight() / 2;
                 break;
             case FloatMenu.LEFT_BOTTOM://左下
-                centerX = getWidth() / 2 - getRadiusAndPadding();
-                centerY = getHeight() / 2 + getRadiusAndPadding();
+                centerX = getMeasuredWidth() / 2 - getRadiusAndPadding();
+                centerY = getMeasuredHeight() / 2 + getRadiusAndPadding();
                 break;
             case FloatMenu.CENTER_TOP://上中
-                centerX = getWidth() / 2;
-                centerY = getHeight() / 2 - getRadiusAndPadding();
+                centerX = getMeasuredWidth() / 2;
+                centerY = getMeasuredHeight() / 2 - getRadiusAndPadding();
                 break;
             case FloatMenu.CENTER_BOTTOM://下中
-                centerX = getWidth() / 2;
-                centerY = getHeight() / 2 + getRadiusAndPadding();
+                centerX = getMeasuredWidth() / 2;
+                centerY = getMeasuredHeight() / 2 + getRadiusAndPadding();
                 break;
             case FloatMenu.RIGHT_TOP://右上
-                centerX = getWidth() / 2 + getRadiusAndPadding();
-                centerY = getHeight() / 2 - getRadiusAndPadding();
+                centerX = getMeasuredWidth() / 2 + getRadiusAndPadding();
+                centerY = getMeasuredHeight() / 2 - getRadiusAndPadding();
                 break;
             case FloatMenu.RIGHT_CENTER://右中
-                centerX = getWidth() / 2 + getRadiusAndPadding();
-                centerY = getHeight() / 2;
+                centerX = getMeasuredWidth() / 2 + getRadiusAndPadding();
+                centerY = getMeasuredHeight() / 2;
                 break;
             case FloatMenu.RIGHT_BOTTOM://右下
-                centerX = getWidth() / 2 + getRadiusAndPadding();
-                centerY = getHeight() / 2 + getRadiusAndPadding();
+                centerX = getMeasuredWidth() / 2 + getRadiusAndPadding();
+                centerY = getMeasuredHeight() / 2 + getRadiusAndPadding();
                 break;
 
             case FloatMenu.CENTER:
-                centerX = getWidth() / 2;
-                centerY = getHeight() / 2;
+                centerX = getMeasuredWidth() / 2;
+                centerY = getMeasuredHeight() / 2;
                 break;
         }
     }
@@ -118,8 +123,10 @@ public class MenuLayout extends ViewGroup implements ICarrier {
      */
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        System.out.println("改变 宽高：mToDegrees:" + mToDegrees + "  mFromDegrees:" + mFromDegrees + "  mChildPadding:" + mChildPadding + "   MIN_RADIUS:" + MIN_RADIUS);
         mRadius = computeRadius(Math.abs(mToDegrees - mFromDegrees), getChildCount(),
                 mChildSize, mChildPadding, MIN_RADIUS);
+        System.out.println("改变 宽高：mRadius:" + mRadius + "  mChildSize:" + mChildSize + "  widthMeasureSpec:" + widthMeasureSpec + "   heightMeasureSpec:" + heightMeasureSpec);
         int layoutPadding = 10;
         int size = mRadius * 2 + mChildSize + mChildPadding + layoutPadding * 2;
         setMeasuredDimension(size, size);
@@ -196,6 +203,17 @@ public class MenuLayout extends ViewGroup implements ICarrier {
         this.position = position;
         mExpanded = !mExpanded;
         isMoving = true;
+        computeCenterXY(position);
+        final int start = mExpanded ? 0 : mRadius;
+        final int radius = mExpanded ? mRadius : -mRadius;
+        mRunner.start(start, 0, radius, 0, duration);
+    }
+
+    /**
+     * 刷新中心按钮状态
+     */
+    public void refreshState(int position, int duration) {
+        this.position = position;
         computeCenterXY(position);
         final int start = mExpanded ? 0 : mRadius;
         final int radius = mExpanded ? mRadius : -mRadius;


### PR DESCRIPTION
修复子菜单个数超过3个时，菜单在屏幕中间和屏幕两边的切换时造成位置错乱的问题。
子菜单超过3个时，菜单重中心移到角落，再打开菜单，会有位置错乱的问题。
分析是在位置移动之后，没有重新计算菜单的宽高的问题。已经修复。代码已经测试过了。没有问题。
（代码可能没有根据楼主的规范来，楼主看到后可以根据思路重新整理下）